### PR TITLE
fix: Add include string.h

### DIFF
--- a/t/ffi/string.c
+++ b/t/ffi/string.c
@@ -1,5 +1,6 @@
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 
 int
 string_matches_foobarbaz(const char *value)


### PR DESCRIPTION
Header `string.h` contains the declaration of `strcmp`.

Testing the module on macOS throws the following error when compiling `t/ffi/string.c` file:

```
CC t/ffi/basic.c
error building t/ffi/_build/string.c.o from t/ffi/string.c at /opt/perlbrew/perls/perl-5.24.4/lib/site_perl/5.24.4/darwin-2level/FFI/Build/File/C.pm line 56.
+cc -fno-common -DPERL_DARWIN -mmacosx-version-min=11.2 -fno-strict-aliasing -pipe -fstack-protector-strong -I/usr/local/include -DPERL_USE_SAFE_PUTENV -O3 -I/opt/perlbrew/perls/perl-5.24.4/lib/site_perl/5.24.4/darwin-2level/auto/share/dist/FFI-Platypus/include -c t/ffi/string.c -o t/ffi/_build/string.c.o
t/ffi/string.c:7:11: error: implicitly declaring library function 'strcmp' with type 'int (const char *, const char *)' [-Werror,-Wimplicit-function-declaration]
  return !strcmp(value, "foobarbaz");
          ^
t/ffi/string.c:7:11: note: include the header <string.h> or explicitly provide a declaration for 'strcmp'
```

Here you have the full log: [build.log](https://github.com/PerlFFI/FFI-Platypus-Declare/files/6211296/build.log)